### PR TITLE
feat: lint-rule-enforce-single-quotes enforce single quotes with lint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,6 @@
 {
   "extends": ["next/core-web-vitals", "next/typescript"],
-  "rules": {}
+  "rules": {
+    "quotes": ["error", "single", { "allowTemplateLiterals": true }]
+  }
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -19,6 +19,7 @@ export default [
     rules: {
       '@typescript-eslint/no-unused-vars': 'warn',
       'custom-rules/sort-enums': 'error',
+      quotes: ['error', 'single', { allowTemplateLiterals: true }],
     },
   },
 ];

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,7 +16,7 @@ const geistMono = localFont({
 
 export const metadata: Metadata = {
   title: 'Femlives',
-  description: "Dedicated to women's health",
+  description: `Dedicated to women's health`,
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## Description

Enforces single quotes but still allows backtics


- [ x] 🙅‍♀️ No leftover console.logs
- [x ] 🦾 Sufficient tests, e. g. unit test
- [x ] 🫶 Documentation updated where necessary
- [ x] 🧠 Left over TODOs are marked with a url to the ticket
